### PR TITLE
Fix broken bert embeddings extractor

### DIFF
--- a/bert_embed.py
+++ b/bert_embed.py
@@ -97,7 +97,7 @@ def ee(model, data):
         tokens = sent.split()
         tokenized = tokenizer(sent, return_tensors='pt', add_special_tokens=False)
         subtokens = tokenizer.convert_ids_to_tokens(tokenized["input_ids"][0])
-        token_reps, _ = model(**tokenized)
+        token_reps = model(**tokenized)["last_hidden_state"]
         token_reps = token_reps.squeeze(0)
         assert len(subtokens) == len(token_reps)
         ave_reps = average_reps(subtokens, token_reps, tokens)


### PR DESCRIPTION
Currently, `bert_embed.py` fails with

```
File "bert_embed.py", line 104, in ee
    token_reps = token_reps.squeeze(0)
AttributeError: 'str' object has no attribute 'squeeze'
```
(HuggingFace Transformers 4.14.1, `bert-base-multilingual-cased`)

That's because `token_reps` contains only a string, one of the keys of the [BaseModelOutputWithPoolingAndCrossAttentions ](https://huggingface.co/docs/transformers/main_classes/output#transformers.modeling_outputs.BaseModelOutputWithCrossAttentions)object.

I guess the idea here is to get the final representations from the model, so I changed  `token_reps, _ = model(**tokenized)` to `token_reps = model(**tokenized)["last_hidden_state"]`. Or may be it should be `hidden_states`, to get representations from all layers?